### PR TITLE
Lower case plugin id

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.4",
   "description": "Add Native TabBar to your Cordova Applications",
   "cordova": {
-    "id": "cordova-plugin-CDVTabBar",
+    "id": "cordova-plugin-cdvtabbar",
     "platforms": [
       "ios"
     ]

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-CDVTabBar"
+    id="cordova-plugin-cdvtabbar"
     version="2.1.4">
     <name>CDVTabBar</name>
     <description>Cordova TabBar Plugin</description>


### PR DESCRIPTION
Nowadays impossible to install the plugin on latest Cordova
Error:
```
'cordova-plugin-CDVTabBar@latest' is not in the npm registry.\nYour package name is not valid, because \n 1. name can no longer contain capital letters\n\nNote that you can also install from a\ntarball, folder, http url, or git url
```